### PR TITLE
Port original snippets to UltiSnips format including some minor tweaks

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -1,0 +1,137 @@
+#
+#  React snippets
+#
+
+snippet cs "React.addons.classSet" b
+var cx = React.addons.classSet;
+endsnippet
+
+snippet cdm "component did mount" b
+componentDidMount: function() {
+	${1}
+},$0
+endsnippet
+
+snippet cdup "component did update" b
+componentDidUpdate: function(prevProps, prevState) {
+	${1}
+},$0
+endsnippet
+
+snippet cwm "component will mount" b
+componentWillMount: function() {
+	${1}
+},$0
+endsnippet
+
+snippet cwr "component will receive props" b
+componentWillReceiveProps: function(nextProps) {
+	${1}
+},$0
+endsnippet
+
+snippet cwun "component will unmount" b
+componentWillUnmount: function() {
+	${1}
+},$0
+endsnippet
+
+snippet cwu "component will update" b
+componentWillUpdate: function(nextProps, nextState) {
+	${1}
+},$0
+endsnippet
+
+snippet cx
+cx({
+	${1}: ${2}
+});
+endsnippet
+
+snippet fup
+forceUpdate(${1:callback});
+endsnippet
+
+snippet gdp "get default props" b
+getDefaultProps: function() {
+	return {
+		${1}
+	};
+},$0
+endsnippet
+
+snippet gis "get initial state" b
+getInitialState: function() {
+	return {
+		${1}: ${2}
+	};
+},$0
+endsnippet
+
+snippet ism "is mounted"
+isMounted()
+endsnippet
+
+snippet jsx "define jsx dom" b
+/**
+ * @jsx React.DOM
+ */
+endsnippet
+
+snippet pt "propTypes" b
+propTypes: {
+	${1}: React.PropTypes.${2:string}
+},
+endsnippet
+
+snippet rcc "create class/component" b
+${1:/**
+* @jsx React.DOM
+*/
+
+var React = require('React');
+}
+var ${2:ClassName} = React.createClass({
+
+render: function() {
+	return (
+		${VISUAL}$4
+	);
+}
+
+});
+$0
+${3:module.exports = $2;}
+endsnippet
+
+snippet ren
+render: function() {
+	return (
+		${1:<div />}
+	);
+}$0
+endsnippet
+
+snippet sst "set state" b
+this.setState({
+	${1}: ${2}
+});$0
+endsnippet
+
+snippet scu "should component update"
+shouldComponentUpdate: function(nextProps, nextState) {
+	${1}
+},$0
+endsnippet
+
+snippet props "get property" i
+this.props.${1}
+endsnippet
+
+snippet state "get state" i
+this.state.${1}
+endsnippet
+
+snippet trp
+this.transferPropsTo(${VISUAL}$0);
+endsnippet


### PR DESCRIPTION
# Pullrequest description

This Pullrequest implements [Ultisnips](https://github.com/SirVer/ultisnips) support by porting the original snippets to the UltiSnips format.
I also made a few minor tweaks:
- make it possible to expand some snippets midsentence. This comes in handy in the following usecase:
  `<div>{state<tab>` Previously state wouldnt expand to `this.state` because of the `{` 
-  Allow the user to skip over some parts of the `React.CreateClass` snippet by changing the `jsx dom defenition`, `requirejs` and `module.exports` parts to separate snippet tabstops that can be removed or overridden. This gives the user more flexibility in reusing the createClass snippet multiple times inside the document without introducing a new snippet.
- Add `$0` to all component functions like `render`, `componentWillMount` etc. This allows the user to skip to the end when they implemented the method and thus chain methods more easily.
- Append `this` to some snippets because it's the most common usecase. For example: `this.setState()` instead of `setState()`
# IMPORTANT: merging / implementation Notes

As to the merging strategy, I think it's best to have a separate branch at all times for the UltiSnips This allows vim-snipmate users to use the `master` branch and allows UltiSnips users to take advantage of some of the features that UltiSnips provides.

If you combine this branch with master, then UltiSnips users will have conflicting snippets because it supports snipmate aswell.

One thing to keep in mind is that we should also update the documentation to let UltiSnips users know they can just checkout the UltiSnips branch, this is possible with most Vim plugin managers.

Also all future UltiSnips functionality should be created by making a featureBranch based on the UltiSnips branch.

I suggest you create a branch on your repository called `UltiSnippets` and base it off master then close this PR, that will be a sign for me that i can rebase my featureBranch on the new UltiSnippets branch and re-create the pullrequest.
