### PR TITLE
rcc: react create class should only create class

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -76,18 +76,6 @@ snippet jsx "define jsx dom" b
 /**
  * @jsx React.DOM
  */
-endsnippet
-
-snippet pt "propTypes" b
-propTypes: {
-	${1}: React.PropTypes.${2:string}
-},
-endsnippet
-
-snippet rcc "create class/component" b
-${1:/**
-* @jsx React.DOM
-*/
 
 var React = require('react');
 }
@@ -102,6 +90,25 @@ render: function() {
 });
 $0
 ${3:module.exports = $2;}
+endsnippet
+
+snippet pt "propTypes" b
+propTypes: {
+	${1}: React.PropTypes.${2:string}
+},
+endsnippet
+
+snippet rcc "create class/component" b
+var ${1:ClassName} = React.createClass({
+
+render: function() {
+	return (
+		${VISUAL}$2
+	);
+}
+
+});
+$0
 endsnippet
 
 snippet ren

--- a/snippets/javascript.snippets
+++ b/snippets/javascript.snippets
@@ -48,14 +48,6 @@ snippet jsx
 	/**
 	 * @jsx React.DOM
 	 */
-snippet pt
-	propTypes: {
-		${1}: React.PropTypes.${2:string}
-	},
-snippet rcc
-	/**
-	 * @jsx React.DOM
-	 */
 
 	var React = require('react');
 
@@ -70,6 +62,20 @@ snippet rcc
 	});
 
 	module.exports = $1;
+snippet pt
+	propTypes: {
+		${1}: React.PropTypes.${2:string}
+	},
+snippet rcc
+	var ${1:ClassName} = React.createClass({
+
+		render: function() {
+			return (
+				${0:<div />}
+			);
+		}
+
+	});
 snippet ren
 	render: function() {
 		return (


### PR DESCRIPTION
The role of `rcc` should be limited to creating classes, nothing more.

`jsx` seems a good candidate for all the bells and whistles (even tough `@jsx` pragma is not required anymore)